### PR TITLE
Typo when clearing timer

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ instance.prototype.clear = function () {
 
 	self.status(self.STATUS_WARNING,"Initializing");
 	
-	if (self.plScan) {
+	if (self.plPoll) {
 		clearInterval(self.plPoll);
 		delete self.plPoll;
 	}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"legacy": [
 		"vlc"
 	],
-	"version": "1.1.0.",
+	"version": "1.1.1",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Video",


### PR DESCRIPTION
Fixes a stale timer when module is disabled.
Don't know how this slipped by. 