### PR TITLE
Warn if VLC's password is blank

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -77,3 +77,4 @@ On the Main Interfaces-->Lua page, set the password for Companion access.
 
 ![setup2](images/VLCSetup2.png "Setup2")
 
+***Note:** VLC must be closed and restarted for the password to take effect.*

--- a/README.md
+++ b/README.md
@@ -42,3 +42,6 @@ See HELP.md and LICENSE
 
 **V1.1.6**
 * Prevent re-initializing variables if module is being disabled
+
+**V1.1.7**
+* Catch non-JSON response when VLC's password is empty

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ See HELP.md and LICENSE
 * Add ID option for feedback colors
 
 **V1.1.6**
-* Prevent re-initializing variables if module is being disabled
+* Prevent re-initializing variables while the module is being disabled
 
 **V1.1.7**
 * Catch non-JSON response when VLC's password is empty

--- a/README.md
+++ b/README.md
@@ -45,3 +45,4 @@ See HELP.md and LICENSE
 
 **V1.1.7**
 * Catch non-JSON response when VLC's password is empty
+* Additional documentation

--- a/README.md
+++ b/README.md
@@ -46,3 +46,4 @@ See HELP.md and LICENSE
 **V1.1.7**
 * Catch non-JSON response when VLC's password is empty
 * Additional documentation
+* adjust rgb to self.rgb

--- a/index.js
+++ b/index.js
@@ -630,6 +630,14 @@ instance.prototype.getRequest = function(url, cb) {
 			}
 		} else if (response.statusCode != 200) {
 			self.show_error( { message: response.statusMessage } );
+		} else if (data[0]!='{') {
+			// if VLC password is empty, it sends an HTML page instead of JSON
+			if (self.lastStatus != self.STATUS_WARNING) {
+				emsg = 'Set the VLC Password';
+				self.status(self.STATUS_WARNING, emsg);
+				self.log('error', emsg);
+				self.lastStatus = self.STATUS_WARNING;
+			}
 		} else {
 			if (self.lastStatus != self.STATUS_OK) {
 				self.status(self.STATUS_OK);

--- a/index.js
+++ b/index.js
@@ -636,7 +636,7 @@ instance.prototype.getRequest = function(url, cb) {
 			// otherwise it is probably the HTML page from VLC
 			// complaining about the password being empty
 			if (self.lastStatus != self.STATUS_WARNING) {
-				emsg = 'Set the VLC Password';
+				emsg = 'Set the Lua HTTP Password in VLC';
 				self.status(self.STATUS_WARNING, emsg);
 				self.log('error', emsg);
 				self.lastStatus = self.STATUS_WARNING;

--- a/index.js
+++ b/index.js
@@ -631,8 +631,8 @@ instance.prototype.getRequest = function(url, cb) {
 			}
 		} else if (response.statusCode != 200) { // page OK
 			self.show_error( { message: response.statusMessage } );
-		} else if (data[0] != '{') {			// but is it JSON?
-			// check 1st character of data for JSON open brace
+		} else if (data[0] != 123) {	// but is it JSON?
+			// check 1st character of data for JSON open brace '{'
 			// otherwise it is probably the HTML page from VLC
 			// complaining about the password being empty
 			if (self.lastStatus != self.STATUS_WARNING) {

--- a/index.js
+++ b/index.js
@@ -234,7 +234,7 @@ instance.prototype.init_feedbacks = function() {
 				type: 'colorpicker',
 				label: 'Background color',
 				id: 'bg',
-				default: rgb(128, 0, 0)
+				default: self.rgb(128, 0, 0)
 			},
 			{
 				type: 'dropdown',
@@ -270,7 +270,7 @@ instance.prototype.init_feedbacks = function() {
 					type: 'colorpicker',
 					label: 'Background color',
 					id: 'bg',
-					default: rgb(0, 128, 0)
+					default: self.rgb(0, 128, 0)
 				},
 				{
 					type: 'textinput',
@@ -317,7 +317,7 @@ instance.prototype.init_feedbacks = function() {
 				type: 'colorpicker',
 				label: 'Background color',
 				id: 'bg',
-				default: rgb(0, 128, 128)
+				default: self.rgb(0, 128, 128)
 			}],
 			callback: function(feedback, bank) {
 				var options = feedback.options;
@@ -337,7 +337,7 @@ instance.prototype.init_feedbacks = function() {
 				type: 'colorpicker',
 				label: 'Background color',
 				id: 'bg',
-				default: rgb(128, 0, 128)
+				default: self.rgb(128, 0, 128)
 			}],
 			callback: function(feedback, bank) {
 				var options = feedback.options;
@@ -357,7 +357,7 @@ instance.prototype.init_feedbacks = function() {
 				type: 'colorpicker',
 				label: 'Background color',
 				id: 'bg',
-				default: rgb(0, 0, 128)
+				default: self.rgb(0, 0, 128)
 			}],
 			callback: function(feedback, bank) {
 				var options = feedback.options;
@@ -377,7 +377,7 @@ instance.prototype.init_feedbacks = function() {
 				type: 'colorpicker',
 				label: 'Background color',
 				id: 'bg',
-				default: rgb(204, 0, 128)
+				default: self.rgb(204, 0, 128)
 			}],
 			callback: function(feedback, bank) {
 				var options = feedback.options;
@@ -778,7 +778,7 @@ instance.prototype.init_presets = function () {
 					type:    'c_status',
 					options: {
 						fg: '16777215',
-						bg: rgb(0, 128, 0),
+						bg: self.rgb(0, 128, 0),
 						playStat: '2'
 					}
 				}
@@ -808,7 +808,7 @@ instance.prototype.init_presets = function () {
 					type:    'c_status',
 					options: {
 						fg: '16777215',
-						bg: rgb(128, 128, 0),
+						bg: self.rgb(128, 128, 0),
 						playStat: '1'
 					}
 				}
@@ -837,7 +837,7 @@ instance.prototype.init_presets = function () {
 					type:    'c_status',
 					options: {
 						fg: '16777215',
-						bg: rgb(128, 0, 0),
+						bg: self.rgb(128, 0, 0),
 						playStat: '0'
 					}
 				}
@@ -864,7 +864,7 @@ instance.prototype.init_presets = function () {
 					type:    'c_loop',
 					options: {
 						fg: '16777215',
-						bg: rgb(0,128,128)
+						bg: self.rgb(0,128,128)
 					}
 				}
 			]
@@ -890,7 +890,7 @@ instance.prototype.init_presets = function () {
 					type:    'c_repeat',
 					options: {
 						fg: '16777215',
-						bg: rgb(128, 0, 128),
+						bg: self.rgb(128, 0, 128),
 						playStat: '0'
 					}
 				}
@@ -917,7 +917,7 @@ instance.prototype.init_presets = function () {
 					type:    'c_random',
 					options: {
 						fg: '16777215',
-						bg: rgb(0, 0, 128),
+						bg: self.rgb(0, 0, 128),
 						playStat: '0'
 					}
 				}
@@ -944,7 +944,7 @@ instance.prototype.init_presets = function () {
 					type:    'c_full',
 					options: {
 						fg: '16777215',
-						bg: rgb(204, 0, 128),
+						bg: self.rgb(204, 0, 128),
 						playStat: '0'
 					}
 				}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"legacy": [
 		"vlc"
 	],
-	"version": "1.1.6",
+	"version": "1.1.7",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Video",


### PR DESCRIPTION
Verify that VLC response starts with '{' before sending to the JSON parser. Otherwise assume the VLC password was not set. A new VLC install does not have a password, yet VLC requires one for remote access.
VLC sends the no-password warning as HTML which would crash the JSON parser.
