### PR TITLE
Pass unexpected VLC response to log

### DIFF
--- a/index.js
+++ b/index.js
@@ -633,10 +633,25 @@ instance.prototype.getRequest = function(url, cb) {
 			self.show_error( { message: response.statusMessage } );
 		} else if (data[0] != 123) {	// but is it JSON?
 			// check 1st character of data for JSON open brace '{'
-			// otherwise it is probably the HTML page from VLC
-			// complaining about the password being empty
+			// otherwise it is probably an HTML page from VLC
+/* 			var resp = data.toString();
+			var vlcErr = resp.match(/!-- (VLC_.*) --/);
+
+			if (vlcErr.length>1) {
+				// VLC Lua password empty?
+				if (vlcErr[1] == 'VLC_PASSWORD_NOT_SET') {
+					emsg = 'Set the Lua HTTP Password in VLC';
+				} else {
+					emsg = 'VLC says ' + vlcErr[1];
+				}
+			} else {
+				emsg = resp;
+			}
+ */
+			// apparently password is not the only issue
+			// so forward VLC response to logs
+			emsg = data.toString();
 			if (self.lastStatus != self.STATUS_WARNING) {
-				emsg = 'Set the Lua HTTP Password in VLC';
 				self.status(self.STATUS_WARNING, emsg);
 				self.log('error', emsg);
 				self.lastStatus = self.STATUS_WARNING;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"legacy": [
 		"vlc"
 	],
-	"version": "1.1.7",
+	"version": "1.1.8",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Video",


### PR DESCRIPTION
VLC periodically sends non-JSON info. This patch passes the VLC message to the log instead of assuming it is a missing password.