### PR TITLE
Add Clear Playlist action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .eslintrc
+.DS_Store

--- a/HELP.md
+++ b/HELP.md
@@ -40,6 +40,7 @@ Action | Description
 **Loop** | Toggle playlist looping mode (cancels repeat mode)
 **Shuffle** | Toggle playlist shuffle (random) mode
 **Repeat** | Toggle item repeat mode (cancels loop mode)
+**Clear Playlist** | Clears all items from the playlist
 
 ## Variables available
 Variable | Description

--- a/index.js
+++ b/index.js
@@ -1046,6 +1046,7 @@ instance.prototype.actions = function(system) {
 		'pause':  { label: 'Pause / Resume'},
 		'next':   { label: 'Next'},
 		'prev':   { label: 'Previous'},
+		'clear':  { label: 'Clear Playlist'},
 		'full':   { label: 'Full Screen'},
 		'loop':   { label: 'Loop'},
 		'shuffle':{ label: 'Shuffle'},
@@ -1093,6 +1094,10 @@ instance.prototype.action = function(action) {
 			cmd = '?command=pl_previous';
 			break;
 
+			case 'clear':
+				cmd = '?command=pl_empty';
+				break;
+
 		case 'full':
 			cmd = '?command=fullscreen';
 			break;
@@ -1126,4 +1131,3 @@ instance.prototype.action = function(action) {
 
 instance_skel.extendedBy(instance);
 exports = module.exports = instance;
-


### PR DESCRIPTION
Added a simple action to clear the current playlist using `?command=pl_empty`. (I am running VLC on a headless Raspberry pi. I can add individual items to my playlist using ssh commands, but want an easy way to clear it.)

Partially deals with #33