### PR TITLE
Use 'number' instead of 'textinput' for vol increment

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -197,9 +197,10 @@ export function GetActionDefinitions(self) {
 			name: 'Set Volume',
 			options: [
 				{
-					type: 'number',
+					type: 'textinput',
 					label: 'Value',
 					id: 'volume',
+					useVariables: true,
 					default: 0,
 				},
 			],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "videolan-vlc",
-	"version": "2.2.0",
+	"version": "2.2.1",
 	"main": "index.js",
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
Volume set needs to distinguish between +10 (increment by 10), 10 (absolute 10), and -10 (decrement by 10)
A 'number' input strips the '+'.
Fixes Issue #61
