### PR TITLE
Add missing defaults to presets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "videolan-vlc",
-	"version": "2.3.5",
+	"version": "2.3.6",
 	"main": "index.js",
 	"type": "module",
 	"scripts": {

--- a/presets.js
+++ b/presets.js
@@ -62,7 +62,7 @@ export function GetPresetDefinitions() {
 					down: [
 						{
 							actionId: 'pause',
-							options: {},
+							options: { opt: 2 },
 						},
 					],
 					up: [],
@@ -75,9 +75,7 @@ export function GetPresetDefinitions() {
 						bgcolor: combineRgb(128, 128, 0),
 						color: 16777215,
 					},
-					options: {
-						playStat: '1',
-					},
+					options: { playStat: '1' },
 				},
 			],
 		},
@@ -132,7 +130,7 @@ export function GetPresetDefinitions() {
 					down: [
 						{
 							actionId: 'loop',
-							options: {},
+							options: { opt: 2 },
 						},
 					],
 					up: [],
@@ -145,7 +143,7 @@ export function GetPresetDefinitions() {
 						bgcolor: combineRgb(0, 128, 128),
 						color: 16777215,
 					},
-					options: {},
+					options: { opt: true },
 				},
 			],
 		},
@@ -164,7 +162,7 @@ export function GetPresetDefinitions() {
 					down: [
 						{
 							actionId: 'repeat',
-							options: {},
+							options: { opt: 2 },
 						},
 					],
 					up: [],
@@ -177,7 +175,7 @@ export function GetPresetDefinitions() {
 						bgcolor: combineRgb(128, 0, 128),
 						color: 16777215,
 					},
-					options: {},
+					options: { opt: true },
 				},
 			],
 		},
@@ -196,7 +194,7 @@ export function GetPresetDefinitions() {
 					down: [
 						{
 							actionId: 'shuffle',
-							options: {},
+							options: { opt: 2 },
 						},
 					],
 					up: [],
@@ -209,7 +207,7 @@ export function GetPresetDefinitions() {
 						bgcolor: combineRgb(0, 0, 128),
 						color: 16777215,
 					},
-					options: {},
+					options: { opt: true },
 				},
 			],
 		},
@@ -228,7 +226,7 @@ export function GetPresetDefinitions() {
 					down: [
 						{
 							actionId: 'full',
-							options: {},
+							options: { opt: 2 },
 						},
 					],
 					up: [],
@@ -241,7 +239,7 @@ export function GetPresetDefinitions() {
 						bgcolor: combineRgb(204, 0, 128),
 						color: 16777215,
 					},
-					options: {},
+					options: { opt: true },
 				},
 			],
 		},
@@ -264,9 +262,7 @@ export function GetPresetDefinitions() {
 					down: [
 						{
 							actionId: 'playID',
-							options: {
-								clip: c,
-							},
+							options: { clip: c },
 						},
 					],
 					up: [],


### PR DESCRIPTION
Some preset buttons did not have useful defaults after v3.0 upgrade
Issue #73 